### PR TITLE
Release 6.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.1.4
+__fixed__
+- ``inputFinalizeGetAmts`` now includes an extra parameter to disable the fee check. Now it is possible to use 
+- Add getters for input and output amounts of psbt transactions.
+
 # 6.1.3
 __added__
 - ``bufferUtils``export. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 6.1.4
 __fixed__
-- ``inputFinalizeGetAmts`` now includes an extra parameter to disable the fee check. Now it is possible to use 
+- ``inputFinalizeGetAmts`` now includes an extra parameter to disable the fee check.  
 - Add getters for input and output amounts of psbt transactions.
 
 # 6.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoin-computer/nakamotojs-lib",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "Client-side Bitcoin and Litecoin JavaScript library",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",


### PR DESCRIPTION
- ``inputFinalizeGetAmts`` now includes an extra parameter to disable the fee check.  
- Add getters for input and output amounts of psbt transactions.